### PR TITLE
feat: harden datasheet validation, repair, and citation flow

### DIFF
--- a/src/fast_foto_forensics/synthesis.py
+++ b/src/fast_foto_forensics/synthesis.py
@@ -111,6 +111,82 @@ def _strip_code_fences(raw_payload: str) -> str:
     return raw
 
 
+def _repair_json(raw: str) -> str:
+    """Best-effort repair of common LLM JSON mistakes.
+
+    Handles:
+    - Markdown code fences (delegated to _strip_code_fences)
+    - Trailing commas before } or ]
+    - Single-quoted strings (only when standard parse fails)
+    - Truncated JSON (unclosed braces/brackets)
+    """
+    import re
+
+    cleaned = _strip_code_fences(raw)
+
+    # Try parsing as-is first
+    try:
+        json.loads(cleaned)
+        return cleaned
+    except json.JSONDecodeError:
+        pass
+
+    # Remove spurious/trailing commas: ,} ,] and repeated commas like ],  ,
+    cleaned = re.sub(r",(\s*,)+", ",", cleaned)  # collapse comma runs
+    cleaned = re.sub(r",\s*([}\]])", r"\1", cleaned)  # strip trailing comma
+    try:
+        json.loads(cleaned)
+        return cleaned
+    except json.JSONDecodeError:
+        pass
+
+    # Try replacing single quotes with double quotes
+    single_quoted = cleaned.replace("'", '"')
+    try:
+        json.loads(single_quoted)
+        return single_quoted
+    except json.JSONDecodeError:
+        pass
+
+    # Try closing truncated JSON by appending missing braces/brackets
+    opens = cleaned.count("{") - cleaned.count("}")
+    closes = cleaned.count("[") - cleaned.count("]")
+    if opens > 0 or closes > 0:
+        patched = cleaned + ("]" * closes) + ("}" * opens)
+        try:
+            json.loads(patched)
+            return patched
+        except json.JSONDecodeError:
+            pass
+
+    # Give up — return the best we got so the caller gets a clear error
+    return cleaned
+
+
+def _backfill_citations(
+    data: dict[str, Any],
+    observations: list[EvidenceObservation],
+    hits: list[SearchHit],
+) -> dict[str, Any]:
+    """Ensure evidence_refs and search_hit_refs are populated.
+
+    LLMs sometimes drop citation fields even when the evidence was in the
+    prompt.  Backfilling from the actual inputs is safe — the model saw
+    exactly these items.
+    """
+    if not data.get("evidence_refs"):
+        data["evidence_refs"] = [obs.evidence_id for obs in observations]
+    if not data.get("search_hit_refs"):
+        data["search_hit_refs"] = [hit.hit_id for hit in hits]
+
+    # Clamp confidence to [0.0, 1.0]
+    conf = data.get("confidence")
+    if isinstance(conf, (int, float)):
+        data["confidence"] = max(0.0, min(1.0, float(conf)))
+
+    return data
+
+
 def _coerce_artifact(
     generated: SynthesisArtifact | str,
     backend: SynthesisBackend,
@@ -299,7 +375,12 @@ def synthesize_item_with_artifact(
     hits: list[SearchHit],
     backend: SynthesisBackend,
 ) -> tuple[ItemDatasheet, SynthesisArtifact]:
-    """Generate and validate a structured datasheet plus provenance."""
+    """Generate and validate a structured datasheet plus provenance.
+
+    On each attempt the raw payload goes through JSON repair (trailing
+    commas, code fences, truncation) and citation backfill before
+    schema validation.  Two attempts are made before giving up.
+    """
     last_artifact: SynthesisArtifact | None = None
 
     for attempt in range(1, 3):
@@ -316,8 +397,28 @@ def synthesize_item_with_artifact(
             raise SynthesisFailure(last_artifact) from exc
 
         artifact = replace(artifact, attempt_count=attempt)
+
+        # Repair common LLM output issues before validation
+        repaired = _repair_json(artifact.raw_payload)
+        if repaired != artifact.raw_payload:
+            artifact = replace(artifact, raw_payload=repaired)
+
         try:
-            datasheet = ItemDatasheet.from_json(artifact.raw_payload)
+            data = json.loads(repaired)
+        except json.JSONDecodeError as exc:
+            last_artifact = replace(
+                artifact,
+                accepted=False,
+                last_error=f"invalid JSON: {exc}",
+                attempt_count=attempt,
+            )
+            continue
+
+        # Backfill citations and clamp confidence
+        data = _backfill_citations(data, observations, hits)
+
+        try:
+            datasheet = ItemDatasheet.from_dict(data)
         except ValueError as exc:
             last_artifact = replace(
                 artifact,

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -11,7 +11,11 @@ from fast_foto_forensics.synthesis import (
     OllamaDatasheetSynthesisBackend,
     RemoteDatasheetSynthesisBackend,
     ReplaySynthesisBackend,
+    SynthesisFailure,
+    _backfill_citations,
+    _repair_json,
     synthesize_item,
+    synthesize_item_with_artifact,
 )
 
 
@@ -246,3 +250,150 @@ def test_remote_backend_stub_fails_fast_with_actionable_error() -> None:
 
     with pytest.raises(RuntimeError, match="not implemented"):
         backend.generate(observations=[], hits=[])
+
+
+# ---------------------------------------------------------------------------
+# JSON repair (#36)
+# ---------------------------------------------------------------------------
+
+_VALID_DATASHEET = {
+    "probable_identity": "Linksys WRT54G",
+    "object_class": "router",
+    "likely_function": "Wireless router",
+    "manufacturer": "Linksys",
+    "model_identifiers": ["WRT54G"],
+}
+
+_OBS = EvidenceObservation(
+    evidence_id="img-1",
+    source_path="rack-a/router.jpg",
+    media_kind="image",
+    sha256="abc",
+    order_index=0,
+    caption="A blue Linksys router.",
+    ocr_text="WRT54G",
+    detected_labels=["router"],
+    candidate_identifiers=["WRT54G"],
+)
+
+_HIT = SearchHit(
+    hit_id="hit-1",
+    provider="duckduckgo",
+    query="WRT54G",
+    title="Linksys WRT54G",
+    snippet="The WRT54G is a wireless router series.",
+    url="https://example.com/wrt54g",
+)
+
+
+def test_repair_json_strips_trailing_commas() -> None:
+    """Trailing commas before } or ] should be removed."""
+    raw = '{"a": 1, "b": [2, 3,],}'
+    repaired = _repair_json(raw)
+    assert json.loads(repaired) == {"a": 1, "b": [2, 3]}
+
+
+def test_repair_json_strips_code_fences() -> None:
+    """Markdown code fences should be stripped."""
+    raw = '```json\n{"a": 1}\n```'
+    repaired = _repair_json(raw)
+    assert json.loads(repaired) == {"a": 1}
+
+
+def test_repair_json_fixes_single_quotes() -> None:
+    """Single-quoted JSON should be converted to double quotes."""
+    raw = "{'a': 1, 'b': 'hello'}"
+    repaired = _repair_json(raw)
+    assert json.loads(repaired) == {"a": 1, "b": "hello"}
+
+
+def test_repair_json_closes_truncated_payload() -> None:
+    """Truncated JSON (missing closing braces) should be patched."""
+    raw = '{"a": 1, "b": [2, 3]'
+    repaired = _repair_json(raw)
+    assert json.loads(repaired) == {"a": 1, "b": [2, 3]}
+
+
+def test_repair_json_passes_valid_json_through() -> None:
+    """Valid JSON should be returned unchanged."""
+    raw = '{"a": 1}'
+    assert _repair_json(raw) == raw
+
+
+def test_backfill_citations_fills_empty_refs() -> None:
+    """Missing evidence_refs and search_hit_refs should be filled from inputs."""
+    data = dict(_VALID_DATASHEET)
+    result = _backfill_citations(data, [_OBS], [_HIT])
+    assert result["evidence_refs"] == ["img-1"]
+    assert result["search_hit_refs"] == ["hit-1"]
+
+
+def test_backfill_citations_preserves_existing_refs() -> None:
+    """Existing evidence_refs should not be overwritten."""
+    data = dict(_VALID_DATASHEET, evidence_refs=["custom-1"], search_hit_refs=["custom-2"])
+    result = _backfill_citations(data, [_OBS], [_HIT])
+    assert result["evidence_refs"] == ["custom-1"]
+    assert result["search_hit_refs"] == ["custom-2"]
+
+
+def test_backfill_citations_clamps_confidence() -> None:
+    """Confidence values outside [0, 1] should be clamped."""
+    data = dict(_VALID_DATASHEET, confidence=1.5)
+    result = _backfill_citations(data, [], [])
+    assert result["confidence"] == 1.0
+
+    data2 = dict(_VALID_DATASHEET, confidence=-0.3)
+    result2 = _backfill_citations(data2, [], [])
+    assert result2["confidence"] == 0.0
+
+
+def test_synthesize_repairs_trailing_comma_payload() -> None:
+    """A payload with trailing commas should be repaired and accepted."""
+    # Valid datasheet but with trailing commas
+    raw = json.dumps({
+        **_VALID_DATASHEET,
+        "confidence": 0.88,
+        "evidence_refs": ["img-1"],
+        "search_hit_refs": ["hit-1"],
+        "open_questions": [],
+    })
+    # Inject trailing commas
+    broken = raw.replace("],", "],  ,").replace("},", "},  ,")
+    # It shouldn't be valid JSON anymore
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(broken)
+
+    backend = ReplaySynthesisBackend(responses=[broken])
+    datasheet, artifact = synthesize_item_with_artifact([_OBS], [_HIT], backend)
+
+    assert datasheet.probable_identity == "Linksys WRT54G"
+    assert artifact.accepted is True
+    assert backend.calls == 1  # No retry needed — repair fixed it
+
+
+def test_synthesize_backfills_missing_citations() -> None:
+    """When the model omits evidence_refs, they should be backfilled."""
+    raw = json.dumps({
+        **_VALID_DATASHEET,
+        "confidence": 0.75,
+        # No evidence_refs or search_hit_refs
+    })
+
+    backend = ReplaySynthesisBackend(responses=[raw])
+    datasheet, artifact = synthesize_item_with_artifact([_OBS], [_HIT], backend)
+
+    assert datasheet.evidence_refs == ["img-1"]
+    assert datasheet.search_hit_refs == ["hit-1"]
+    assert artifact.accepted is True
+
+
+def test_synthesize_gives_up_after_two_bad_payloads() -> None:
+    """Two consecutive unparseable payloads should raise SynthesisFailure."""
+    backend = ReplaySynthesisBackend(responses=["garbage", "still garbage"])
+
+    with pytest.raises(SynthesisFailure) as exc_info:
+        synthesize_item_with_artifact([_OBS], [_HIT], backend)
+
+    assert exc_info.value.artifact.accepted is False
+    assert exc_info.value.artifact.attempt_count == 2
+    assert "invalid JSON" in (exc_info.value.artifact.last_error or "")


### PR DESCRIPTION
## Summary
- Add `_repair_json()` to handle common LLM JSON mistakes: trailing/repeated commas, code fences, single quotes, truncated payloads
- Add `_backfill_citations()` to fill missing `evidence_refs`/`search_hit_refs` from inputs and clamp confidence to [0,1]
- Wire both into `synthesize_item_with_artifact()` so repair + backfill happen before schema validation on each attempt
- 11 new tests covering repair, backfill, and end-to-end synthesis edge cases

Closes #36

## Test plan
- [x] All 16 synthesis tests pass
- [x] Full CI-safe suite (90 tests) passes
- [ ] CI workflow confirms no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)